### PR TITLE
Add mapping for gemma-7b-it

### DIFF
--- a/llm_groq.py
+++ b/llm_groq.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Union
 def register_models(register):
     register(LLMGroq("groq-llama2"))
     register(LLMGroq("groq-mixtral"))
+    register(LLMGroq("groq-gemma"))
 
 class LLMGroq(llm.Model):
     can_stream = True
@@ -16,6 +17,7 @@ class LLMGroq(llm.Model):
     model_map: dict = {
         "groq-llama2": "llama2-70b-4096",
         "groq-mixtral": "mixtral-8x7b-32768",
+        "groq-gemma": "gemma-7b-it",
     }
 
     class Options(llm.Options):


### PR DESCRIPTION
Tested locally using [`llm` instructions](https://llm.datasette.io/en/stable/plugins/tutorial-model-plugin.html)

```sh
❯ llm models
OpenAI Chat: gpt-3.5-turbo (aliases: 3.5, chatgpt)
OpenAI Chat: gpt-3.5-turbo-16k (aliases: chatgpt-16k, 3.5-16k)
OpenAI Chat: gpt-4 (aliases: 4, gpt4)
OpenAI Chat: gpt-4-32k (aliases: 4-32k)
OpenAI Chat: gpt-4-1106-preview
OpenAI Chat: gpt-4-0125-preview
OpenAI Chat: gpt-4-turbo-preview (aliases: gpt-4-turbo, 4-turbo, 4t)
OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
LLMGroq: groq-llama2
LLMGroq: groq-mixtral
LLMGroq: groq-gemma

❯ llm -m groq-gemma 'test'
Sure, what would you like me to do with the text "test"? Would you like me to:

* **Explain the meaning of the word "test"?**
* **Provide examples of the word "test" in a sentence?**
* **Discuss the different usages of the word "test"?**
* **Something else?**

Please let me know what you would like me to do.
```