### PR TITLE
use response.text_or_raise() so finished AsyncResponses work

### DIFF
--- a/llm_groq.py
+++ b/llm_groq.py
@@ -204,7 +204,7 @@ class _Shared:
                 messages.append(
                     {"role": "user", "content": prev_response.prompt.prompt}
                 )
-            messages.append({"role": "assistant", "content": prev_response.text()})
+            messages.append({"role": "assistant", "content": prev_response.text_or_raise()})
         if prompt.system and current_system != prompt.system:
             messages.append({"role": "system", "content": prompt.system})
 


### PR DESCRIPTION
at the moment, it calls `response.text()` instead of `response.text_or_raise()`, so if you're using an `AsyncResponse` it will give you back a `Coroutine`, which errors down the way because you can't json-serialize one of those.

if the conversation object has an `AsyncResponse` that isn't `_done` this will raise, but they should only add themselves to the conversation after `__aiter__` is finished so it won't ever happen as far as I can tell.