### PR TITLE
fix: detect vision models using input_modalities from Groq API

### DIFF
--- a/llm_groq.py
+++ b/llm_groq.py
@@ -27,7 +27,7 @@ def register_models(register):
     for model in models:
         groq_model_id = model["id"]
         model_id = "groq/{}".format(groq_model_id)
-        vision = "-vision" in model_id
+        vision = "image" in model.get("input_modalities", [])
         aliases = ()
         if groq_model_id in OLD_ALIASES_REVERSE:
             aliases = (OLD_ALIASES_REVERSE[groq_model_id],)


### PR DESCRIPTION
The previous approach checked for '-vision' in the model ID which fails for models like llama-4-scout-17b-16e-instruct and qwen3.6-27b that support image input but don't have '-vision' in their name.

Groq's API returns input_modalities for each model. Use that field directly to detect vision support — more accurate and future-proof.

Tested with:
- groq/meta-llama/llama-4-scout-17b-16e-instruct: working image input
- groq/qwen/qwen3.6-27b: working image input